### PR TITLE
PI-1687 Escape text before attempting to highlight

### DIFF
--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -40,6 +40,7 @@ describe('highlightText', () => {
       ['hello', 'world'],
       '<span class="highlighted-text">Hello</span> <span class="highlighted-text">world</span>',
     ],
+    ['Hello world)', ['world)'], 'Hello <span class="highlighted-text">world)</span>'],
   ])('should highlight text correctly', (textToHighlight, searchWords, expected) => {
     expect(highlightText(textToHighlight, searchWords)).toEqual(expected)
   })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -26,7 +26,7 @@ export const initialiseName = (fullName?: string): string | null => {
 
 export const highlightText = (textToHighlight?: string, searchWords?: string[]): string =>
   searchWords && searchWords.length > 0
-    ? findAll({ searchWords, textToHighlight })
+    ? findAll({ searchWords, textToHighlight, autoEscape: true })
         .map(({ end, highlight, start }: Chunk) => {
           const text = textToHighlight.substring(start, end)
           return highlight ? `<span class="highlighted-text">${text}</span>` : text


### PR DESCRIPTION
This fixes highlighting where the text has regular expression characters in it.  Previously the test fails with:
```
SyntaxError: Invalid regular expression: /Hello world)/gi
```

Fixes https://ministryofjustice.sentry.io/issues/4662527242