### PR TITLE
PI-1696 Handle highlighting for undefined string

### DIFF
--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -31,7 +31,8 @@ describe('initialise name', () => {
 
 describe('highlightText', () => {
   it.each([
-    [undefined, undefined, undefined],
+    [undefined, undefined, ''],
+    [undefined, ['undefined'], ''],
     ['Hello world', undefined, 'Hello world'],
     ['Hello world', ['world'], 'Hello <span class="highlighted-text">world</span>'],
     ['Hello world', ['hello'], '<span class="highlighted-text">Hello</span> world'],

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -24,12 +24,13 @@ export const initialiseName = (fullName?: string): string | null => {
   return `${array[0][0]}. ${array.reverse()[0]}`
 }
 
-export const highlightText = (textToHighlight?: string, searchWords?: string[]): string =>
-  searchWords && searchWords.length > 0
-    ? findAll({ searchWords, textToHighlight, autoEscape: true })
-        .map(({ end, highlight, start }: Chunk) => {
-          const text = textToHighlight.substring(start, end)
-          return highlight ? `<span class="highlighted-text">${text}</span>` : text
-        })
-        .join('')
-    : textToHighlight
+export const highlightText = (textToHighlight?: string, searchWords?: string[]): string => {
+  if (!textToHighlight) return ''
+  if (!searchWords || searchWords.length === 0) return textToHighlight
+  return findAll({ searchWords, textToHighlight, autoEscape: true })
+    .map(({ end, highlight, start }: Chunk) => {
+      const text = textToHighlight.substring(start, end)
+      return highlight ? `<span class="highlighted-text">${text}</span>` : text
+    })
+    .join('')
+}


### PR DESCRIPTION
The highlighting library incorrectly finds a match if the textToHighlight is undefined, and the search text contains a substring of "undefined", leading to an error later:
```
Template render error: (/app/dist/server/views/pages/deliusSearch/results.njk) [Line 21, Column 34]
...
TypeError: Cannot read properties of undefined (reading 'substring')
```