### PR TITLE
PI-1707 Disable major updates for govuk-frontend

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,13 +15,13 @@
       "stabilityDays": 5
     },
     {
-      "matchPackageNames": ["typescript", "govuk-frontend"],
+      "matchPackageNames": ["typescript", "@ministryofjustice/probation-search-frontend"],
       "rangeStrategy": "bump",
       "stabilityDays": 0
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/node"],
+      "matchPackageNames": ["@types/node", "govuk-frontend"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     }


### PR DESCRIPTION
This ensures we continue to fully support IE11 until we're ready to upgrade.

Also enables instant updates for probation-search-frontend, instead of waiting for 5 days after release.