### PR TITLE
PI-1737 Handle null elements in updateFilters function

### DIFF
--- a/server/views/pages/deliusSearch/index.njk
+++ b/server/views/pages/deliusSearch/index.njk
@@ -85,9 +85,11 @@
       function updateFilters() {
         const url = new URL(location.href);
         url.searchParams.delete("page");
-        url.searchParams.set("matchAllTerms", document.querySelector("input[name=\"match-all-terms\"]:checked").value);
         url.searchParams.delete("providers[]");
-        document.querySelectorAll("input[name=\"providers-filter\"]:checked").forEach(el => url.searchParams.append("providers[]", el.value));
+        const el = document.querySelector("input[name=\"match-all-terms\"]:checked");
+        url.searchParams.set("matchAllTerms", !el || el.value);
+        document.querySelectorAll("input[name=\"providers-filter\"]:checked")
+          .forEach(el => el && url.searchParams.append("providers[]", el.value));
         location.href = url.toString();
       }
 


### PR DESCRIPTION
I don't see how `el` can be null here, but we've had a couple of Sentry errors for it. I can recreate it by modifying the DOM in the browser dev tools, and this change fixes it.

Resolves [PROBATION-SEARCH-UI-M](https://ministryofjustice.sentry.io/issues/4703745510).