### PR TITLE
PI-1784 Add explicit path normalization for image endpoint

### DIFF
--- a/helm_deploy/probation-search-ui/values.yaml
+++ b/helm_deploy/probation-search-ui/values.yaml
@@ -4,8 +4,6 @@ generic-service:
 
   serviceAccountName: probation-search-ui
 
-  replicaCount: 4
-
   image:
     repository: quay.io/hmpps/probation-search-ui
     tag: app_version # override at deployment time

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -2,6 +2,12 @@
 # Per environment values which override defaults in probation-search-ui/values.yaml
 
 generic-service:
+  replicaCount: 4
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
   ingress:
     host: probation-search.hmpps.service.justice.gov.uk
 

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -7,10 +7,10 @@ export default class PrisonApiClient extends RestClient {
     super('PrisonApiClient', config.apis.prisonApi, token)
   }
 
-  async getImageData(nomsNumber: string): Promise<Readable> {
-    return (await this.stream({
+  getImageData(nomsNumber: string): Promise<Readable> {
+    return this.stream({
       path: `/api/bookings/offenderNo/${nomsNumber}/image/data`,
       handle404: true,
-    })) as Promise<Readable>
+    })
   }
 }

--- a/server/monitoring/metricsApp.ts
+++ b/server/monitoring/metricsApp.ts
@@ -7,7 +7,10 @@ const metricsMiddleware = promBundle({
   httpDurationMetricName: 'http_server_requests_seconds',
   includeMethod: true,
   includePath: true,
-  normalizePath: [['^/assets/.+$', '/assets/#assetPath']],
+  normalizePath: [
+    ['^/assets/.+$', '/assets/#assetPath'],
+    ['^/delius/nationalSearch/prisoner-image/.+$', '/delius/nationalSearch/prisoner-image/#id'],
+  ],
 })
 
 function metricsPort(): number {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import {
   ProbationSearchResponse,
 } from '@ministryofjustice/probation-search-frontend/data/probationSearchClient'
 import { format, parseISO } from 'date-fns'
+import { Readable } from 'stream'
 import config from '../config'
 import type { Services } from '../services'
 import PrisonApiClient from '../data/prisonApiClient'
@@ -65,7 +66,7 @@ export default function routes(service: Services): Router {
     if (!verifySignedUrl(req)) {
       res.sendStatus(403)
     } else {
-      let data
+      let data: Readable
       if (req.params.prisonerId) {
         const token = await service.hmppsAuthClient.getSystemClientToken()
         data = await new PrisonApiClient(token).getImageData(req.params.prisonerId)


### PR DESCRIPTION
This should prevent Prometheus generating a new object for each NOMIS ID, see https://prometheus.live.cloud-platform.service.justice.gov.uk/graph?g0.expr=http_server_requests_seconds_count%20%7Bnamespace%3D%22hmpps-probation-search-prod%22%2C%20path%3D~%22%2Fdelius%2FnationalSearch%2Fprisoner-image%2F.*%22%7D&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1m

Also,
+ tidy up streaming code
+ request more realistic resources in prod