### PR TITLE
PI-2125 Reduce Sentry error replay sampling to 10%

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -56,6 +56,7 @@ export default {
     environment: get('ENVIRONMENT_NAME', 'local', requiredInProduction),
     tracesSampleRate: Number(get('SENTRY_TRACES_SAMPLE_RATE', 0.05)),
     replaySampleRate: Number(get('SENTRY_REPLAY_SAMPLE_RATE', 0.0)),
+    replayOnErrorSampleRate: Number(get('SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE', 0.1)),
   },
   delius: {
     url: get('DELIUS_URL', '*', requiredInProduction),

--- a/server/views/partials/sentry.njk
+++ b/server/views/partials/sentry.njk
@@ -9,7 +9,7 @@
         integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
         tracesSampleRate: {{ sentry.tracesSampleRate }},
         replaysSessionSampleRate: {{ sentry.replaySampleRate }},
-        replaysOnErrorSampleRate: 1.0, // Capture replays for any sessions with an error
+        replaysOnErrorSampleRate: {{ sentry.replayOnErrorSampleRate }},
         initialScope: {
           user: { username: "{{ user.username }}" },
         },


### PR DESCRIPTION
As suggested in https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/sentry.html#replay-session-sampling-rate