### PR TITLE
PI-2620 Open external links in new window

### DIFF
--- a/assets/js/delius.js
+++ b/assets/js/delius.js
@@ -121,6 +121,9 @@
     document.getElementById('add-new-person-link').addEventListener('click', () => postMessage('addOffender'))
     document.getElementById('previous-search-link').addEventListener('click', () => postMessage('toggleSearch'))
 
+    // Open external links in a new window
+    document.querySelectorAll('a[href*="//"]').forEach(a => (a.target = '_blank'))
+
     // Focus on input
     const search = document.getElementById('search')
     search.focus() // the autofocus attribute doesn't work in a cross-origin iframe


### PR DESCRIPTION
This fixes footer links refusing to load when the Delius search page is loaded in an iframe